### PR TITLE
Explicitly add app name to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ deploy:
   provider: heroku
   api_key:
     secure: RJhFd/bVJnfOmlNQPESFgU4nh6o5ELXsa5WHLE9gQEoSdWKcS1akCcsaW0Zc+jCMqWoXSe+2DMQQ5XkCeZ4NK6t29US+cLcXKFtt+QnB/hrNKyv/h3DbAvKdqsxXJko8JYeeseRcc+gtTOx8OF2FV4XJOk/j1qVxwSsay4PE/KAops1OziGXSnex4K+71KKvtpOx5Mo1dqfxs49gxBQUsymAAvo1B6OpVJtAID7dnOyyqNUKlbXoSrNb1O+3vl2nUoFD+Q67nmMi33iRCKOsAv0XjeGRsmkVqZDuHs1afvS6mWHGGfCvVFtXkT/YWZGPQm5y0Oc9x1pv1+J+MZT9O0fAlokkZfhld1qX6XB4UF+KE/0kjnINiAtQdXUA7tFlzCTK9u06AAZIyPFavSmgS5hPozAnEv/zYDKHbGolSL9+npcyj86VO6vI68N+/Dljx4BrMg9tA9sINszr5dTJHZ2AXAH6VGbonDyCLk6DBrNcrjzVbdPCp8o209xc0bG9q2Ewa7VVHiZQaK1ueatspL6iOAohZ9hVoZF0OyAmnaHLIYOpGLhVMvcPNahAL1Wen7f1+jxcUTGJfGv1wjEpTHPbXccrhjzB2BSllQ7s4ZTRUpPGmFB683rj2tq5asFRJicgfrtKaldnLLrqr0s3T1MSvglsjrTa725YfpVvNRg=
-  app:
+  app: peaceful-journey-75998
   run: rails db:migrate
   on:
     repo: Kathybui732/viewing_party


### PR DESCRIPTION
Travis CI was failing to deploy to Heroku because it didn't know what app to find.

This PR will close #33 