### PR TITLE
Movie results title links

### DIFF
--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -15,8 +15,8 @@
 <section class="results">
   <% unless @movies.nil? %>
     <% @movies.each do |movie| %>
-      <article class="movie-<%= movie.tmdb_id %>">
-        <%= link_to "#{movie.title}", movie_path(movie)%>
+      <article id="movie-<%= movie.tmdb_id %>" class="movie">
+        <%= link_to "#{movie.title}", movie_path(movie.tmdb_id)%>
         <%= tag.span "Vote Average: #{movie.vote_average.round(1)}" %>
       </article>
     <% end %>

--- a/spec/features/movies/movie_result_titles_are_links_spec.rb
+++ b/spec/features/movies/movie_result_titles_are_links_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Movie title links" do
+  describe "As an authenticated user" do
+    before :each do
+      @user = User.create!(user_id: "100000000000000000000", name: "John Smith")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    end
+
+    describe "Movies index page" do
+      it "has links to the movie's show page from top rated query" do
+        visit movies_path
+        click_on "Top Rated"
+        within(first(".movie")) do
+          expect(page).to have_link("Gabriel's Inferno Part II", href: '/movies/724089')
+        end
+      end
+
+      it "has links to the movie's show page from search query" do
+        visit movies_path
+        fill_in :movie_title_keywords, with: "Avengers"
+        click_on "Find Movies"
+        within(first(".movie")) do
+          expect(page).to have_link("Avengers: Infinity War", href: '/movies/299536')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Add feature movie title links
closes #10 

### Merging branches: 
[movie_results_title_links](https://github.com/Kathybui732/viewing_party/tree/movie_results_title_links) into [main](https://github.com/Kathybui732/viewing_party/tree/main)

### Features added:
- Movie results populated on movies index page via ***top rated search*** now have titles that are links to their movie show page
- Movie results populated on movies index page via ***title keyword search*** now have titles that are links to their movie show page

### To be completed:
- Adding a mock/stub in order to optimize testing