### PR TITLE
Add tests for POROS

### DIFF
--- a/spec/poros/cast_member_spec.rb
+++ b/spec/poros/cast_member_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe CastMember do
+  it "exists with attributes" do
+    cast_member_params = {name: "AJ", character: "This was good"}
+    cast_member = CastMember.new(cast_member_params)
+    expect(cast_member.class).to eq(CastMember)
+    expect(cast_member.actor).to eq(cast_member_params[:name])
+    expect(cast_member.character).to eq(cast_member_params[:character])
+  end
+end

--- a/spec/poros/movie_spec.rb
+++ b/spec/poros/movie_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Movie do
+  it "exists with attributes" do
+    cassette = 'spec/fixtures/vcr_cassettes/Movie_Show_Page/As_an_authenticated_user/I_can_see_movie_details.yml'
+    movie_details = File.read(cassette)
+    yaml = YAML.load(movie_details, symbolize_names: true)
+    json = yaml[:http_interactions][2][:response][:body][:string]
+    movie_params = JSON.parse(json, symbolize_names: true)
+    movie = Movie.new(movie_params)
+
+    expect(movie.class).to eq(Movie)
+
+    expect(movie.cast_members.class).to eq(Array)
+    expect(movie.description.class).to eq(String)
+    expect(movie.genres.class).to eq(Array)
+    expect(movie.reviews.class).to eq(Array)
+    expect(movie.reviews_count.class).to eq(Integer)
+    expect(movie.runtime.class).to eq(Integer)
+    expect(movie.title.class).to eq(String)
+    expect(movie.tmdb_id.class).to eq(Integer)
+    expect(movie.vote_average.class).to eq(Float)
+  end
+end

--- a/spec/poros/review_spec.rb
+++ b/spec/poros/review_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Review do
+  it "exists with attributes" do
+    review_params = {author: "AJ", content: "This was good"}
+    review = Review.new(review_params)
+    expect(review.class).to eq(Review)
+    expect(review.author).to eq(review_params[:author])
+    expect(review.content).to eq(review_params[:content])
+  end
+end


### PR DESCRIPTION
New specs for `review.rb`, `cast_member.rb` and `movie.rb`

`movie_spec.rb` uses a fixture from the `vcr_cassettes` directory.
There is some YAML and JSON parsing in order to get the params to instantiate a Movie and test its methods.