### PR TITLE
Add feature: Viewing Parties are now displayed on the dashboard

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -29,3 +29,14 @@ footer {
   align-self: baseline;
   flex-direction: row;
 }
+
+.party-container {
+  display: flex;
+}
+
+.party {
+  width: 200px;
+  margin-right: 75px;
+  border-color: blue;
+  border-style: solid;
+}

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,3 +1,5 @@
 class DashboardController < BaseController
-  def index; end
+  def index
+    @parties = Party.all
+  end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -24,10 +24,11 @@
   <h1>Viewing Parties</h1>
   <div class="party-container">
     <% @parties.each do |party| %>
-      <div class="party">
+      <div class="party" id="party-<%= party.id %>">
         <%= tag.p "Movie: #{party.movie_title}" %>
         <%= tag.p "Date: #{party.date}" %>
         <%= tag.p "Time: #{party.time}" %>
+        <%= button_to "Add to Calendar" unless current_user.parties.include?(party) %>
       </div>
     <% end %>
   </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -22,4 +22,13 @@
 
 <section class="viewing-party">
   <h1>Viewing Parties</h1>
+  <div class="party-container">
+    <% @parties.each do |party| %>
+      <div class="party">
+        <%= tag.p "Movie: #{party.movie_title}" %>
+        <%= tag.p "Date: #{party.date}" %>
+        <%= tag.p "Time: #{party.time}" %>
+      </div>
+    <% end %>
+  </div>
 </section>

--- a/spec/features/dashboard/viewing_party_section_spec.rb
+++ b/spec/features/dashboard/viewing_party_section_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "Dashboard Page Viewing Party Section Spec" do
           expect(page).to have_content(party.movie_title)
           expect(page).to have_content(party.date)
           expect(page).to have_content(party.time)
+          expect(page).to have_button("Add to Calendar")
         end
       end
     end

--- a/spec/features/dashboard/viewing_party_section_spec.rb
+++ b/spec/features/dashboard/viewing_party_section_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Dashboard Page Viewing Party Section Spec" do
+  before :each do
+    @user1 = User.create!(oauth_id: "100000000000000000000", name: "John Smith", email: "john@example.com", access_token: "TOKEN", refresh_token: "REFRESH_TOKEN")
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user1)
+    current_date = DateTime.now.to_date.to_s
+    current_time = DateTime.now.to_time.to_s[11..15]
+    @party1 = Party.create!(user: @user1, date: current_date, time: current_time, movie_title: "Resident Evil", party_duration: 180 )
+    @party2 = Party.create!(user: @user1, date: current_date, time: current_time, movie_title: "Resident Evil 2", party_duration: 180 )
+    @party3 = Party.create!(user: @user1, date: current_date, time: current_time, movie_title: "Resident Evil 3", party_duration: 180 )
+    @parties = [@party1, @party2, @party3]
+  end
+
+  describe "As a logged in user on the dashboard page" do
+    it "There is a section with all my viewing parties" do
+      visit dashboard_index_path
+
+      within ".viewing-party" do
+        @parties.each do |party|
+          expect(page).to have_content(party.movie_title)
+          expect(page).to have_content(party.date)
+          expect(page).to have_content(party.time)
+        end
+      end
+    end
+  end
+end

--- a/spec/features/dashboard/viewing_party_section_spec.rb
+++ b/spec/features/dashboard/viewing_party_section_spec.rb
@@ -2,27 +2,33 @@ require "rails_helper"
 
 RSpec.describe "Dashboard Page Viewing Party Section Spec" do
   before :each do
-    @user1 = User.create!(oauth_id: "100000000000000000000", name: "John Smith", email: "john@example.com", access_token: "TOKEN", refresh_token: "REFRESH_TOKEN")
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user1)
     current_date = DateTime.now.to_date.to_s
     current_time = DateTime.now.to_time.to_s[11..15]
+    @user1 = User.create!(oauth_id: "100000000000000000000", name: "John Smith", email: "john@example.com", access_token: "TOKEN", refresh_token: "REFRESH_TOKEN")
+    @user2 = User.create!(oauth_id: "100000000000000000002", name: "Jane Bulldozer", email: "jane@example.com", access_token: "TOKEN", refresh_token: "REFRESH_TOKEN")
     @party1 = Party.create!(user: @user1, date: current_date, time: current_time, movie_title: "Resident Evil", party_duration: 180 )
-    @party2 = Party.create!(user: @user1, date: current_date, time: current_time, movie_title: "Resident Evil 2", party_duration: 180 )
-    @party3 = Party.create!(user: @user1, date: current_date, time: current_time, movie_title: "Resident Evil 3", party_duration: 180 )
-    @parties = [@party1, @party2, @party3]
+    PartyInvitee.create(party_id: @party1.id, invitee_id: @user2.id)
+    @party2 = Party.create!(user: @user2, date: current_date, time: current_time, movie_title: "John Wick 3", party_duration: 200 )
+    PartyInvitee.create(party_id: @party2.id, invitee_id: @user1.id)
   end
 
-  describe "As a logged in user on the dashboard page" do
-    it "There is a section with all my viewing parties" do
-      visit dashboard_index_path
+  scenario "Add to calendar button exists properly" do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user1)
+    visit dashboard_index_path
 
-      within ".viewing-party" do
-        @parties.each do |party|
-          expect(page).to have_content(party.movie_title)
-          expect(page).to have_content(party.date)
-          expect(page).to have_content(party.time)
-          expect(page).to have_button("Add to Calendar")
-        end
+    within ".viewing-party" do
+      within "#party-#{@party1.id}" do
+        expect(page).to have_content(@party1.movie_title)
+        expect(page).to have_content(@party1.date)
+        expect(page).to have_content(@party1.time)
+        expect(page).to_not have_button("Add to Calendar")
+      end
+
+      within "#party-#{@party2.id}" do
+        expect(page).to have_content(@party2.movie_title)
+        expect(page).to have_content(@party2.date)
+        expect(page).to have_content(@party2.time)
+        expect(page).to have_button("Add to Calendar")
       end
     end
   end


### PR DESCRIPTION
A logged in user will see parties
Events they have been invited to will have a button
The events that they created will not have a button

Screenshot
<img width="800" alt="Screen Shot 2020-08-26 at 9 44 43 PM" src="https://user-images.githubusercontent.com/31839316/91381764-61a5bc00-e7e5-11ea-9c2e-fa7d2e44e8f8.png">
